### PR TITLE
Fixed #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ Routes are mainly for starting a connection with the server. For instance, regis
             "systemstat": false
         }
         ```
-    * Returns: Active websocket connections indicating number of users and number of vehicles. Also provides system info if `systemstat: true`
+    * Returns: Active websocket connections indicating number of users and number of vehicles. Also provides system info if `systemstat: true`. It shouls be noted that an average computer takes ~20ms to measure system resources. So the response time might be delayed with `systemstat: true`.
 
         ```json
         {
             "active_users": 0,
             "active_vehicles": 0,
+            "active_sessions": 0,
             "memory_available": "7.84 GB",
             "memory_used": "2.01 GB",
             "total_swap": "2.10 GB",

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,13 +98,16 @@ async fn main() -> std::io::Result<()> {
     let client = Client::with_options(client_options).unwrap();
     let database = client.database("alpadrive");
     let active_vehicles = Arc::new(RwLock::new(HashMap::<String, String>::new()));
+    let active_sessions = Arc::new(RwLock::new(0));
+    let av_copy = Arc::clone(&active_vehicles);
+    let sessions_copy = Arc::clone(&active_sessions);
 
-    let lobby = Lobby::new(active_vehicles);
+    let lobby = Lobby::new(active_vehicles, active_sessions);
     // let lobby = Lobby::default().start();
 
     HttpServer::new(move || {
         App::new()
-            .app_data(web::Data::new(Manager::start(database.clone(), lobby.clone())))
+            .app_data(web::Data::new(Manager::start(database.clone(), lobby.clone(), Arc::clone(&av_copy), Arc::clone(&sessions_copy))))
             .service(hello)
             .service(login)
             .service(status)


### PR DESCRIPTION
The Rust `std` crate provides a reader-writer lock, by the name of `RwLock`, which can be leveraged to fix this issue. The official documentation states:
> This type of lock allows a number of readers or at most one writer at any point in time. The write portion of this lock typically allows modification of the underlying data (exclusive access) and the read portion of this lock typically allows for read-only access (shared access)

As such, a copy of the `HashMap` of admins (ie, vehicles) being used internally by the `Manager` can be kept in this `RwLock` as well. This can then be updated by the `Lobby` and read by `Manager`. The `active_sessions` in the `Lobby` can also be kept as an `RwLock<usize>` that can be referred to by all threads as and when required.

So, this pull request also lays the groundwork for solving #1 and hence, needs to be merged into main.